### PR TITLE
feat(lumadb): Add LumaDB unified database as optional backend

### DIFF
--- a/anti-call-masking/config/lumadb.yaml
+++ b/anti-call-masking/config/lumadb.yaml
@@ -1,0 +1,112 @@
+# LumaDB Configuration for Anti-Call Masking Detection System
+# =============================================================
+# This replaces kdb+, Kafka, Redis, and PostgreSQL configurations
+
+server:
+  node_id: 1
+  data_dir: /data
+  log_dir: /var/log/lumadb
+
+# API Configuration
+api:
+  rest:
+    host: "0.0.0.0"
+    port: 8080
+    workers: 0  # 0 = auto-detect CPU cores
+    max_connections: 10000
+    request_timeout_secs: 30
+  graphql:
+    host: "0.0.0.0"
+    port: 4000
+    introspection: true
+  grpc:
+    host: "0.0.0.0"
+    port: 50051
+    max_message_size: 16777216  # 16MB
+
+# Kafka Protocol (100% Kafka-compatible)
+# Replaces: Kafka, Redpanda
+kafka:
+  host: "0.0.0.0"
+  port: 9092
+  num_partitions: 3
+  replication_factor: 1
+  batch_size: 16384
+  linger_ms: 5
+  buffer_memory: 33554432  # 32MB
+  retention_ms: 604800000  # 7 days
+  retention_bytes: -1  # Unlimited
+
+# Storage Engine Configuration
+# Replaces: kdb+ time-series storage
+storage:
+  lsm:
+    memtable_size: 67108864  # 64MB
+    level0_compaction_trigger: 4
+    max_levels: 7
+    compression: lz4
+  wal:
+    enabled: true
+    sync_mode: async  # sync, async, none
+    segment_size: 67108864  # 64MB
+  cache:
+    block_cache_size: 1073741824  # 1GB (replaces Redis)
+    index_cache_size: 268435456   # 256MB
+  # Time-series optimizations (replacing kdb+)
+  timeseries:
+    compression: gorilla  # 8-12x compression for numeric data
+    retention_period: 2592000  # 30 days in seconds
+    rollup_enabled: true
+    rollup_intervals: ["1m", "5m", "1h", "1d"]
+  columnar:
+    row_group_size: 65536
+    compression: zstd
+    dictionary_encoding: true
+
+# Streaming Engine (100x faster than Kafka)
+streaming:
+  reactor_threads: 0  # 0 = auto-detect
+  io_depth: 256
+  use_io_uring: true  # Linux kernel bypass
+  batch_size: 1000
+  batch_timeout_us: 100
+
+# Query Engine
+query:
+  max_concurrent_queries: 100
+  query_timeout_secs: 300
+  memory_limit: 2147483648  # 2GB
+  optimizer:
+    enable_predicate_pushdown: true
+    enable_projection_pushdown: true
+    enable_join_reordering: true
+    enable_simd: true  # AVX-512/NEON acceleration
+
+# Security (disabled for development)
+security:
+  auth_enabled: false
+  auth_method: jwt
+  jwt_secret: ""
+  jwt_expiration_secs: 86400
+  tls_enabled: false
+  audit_enabled: false
+
+# Logging
+logging:
+  level: info  # debug, info, warn, error
+  format: json
+  file:
+    enabled: true
+    path: /var/log/lumadb/lumadb.log
+    max_size_mb: 100
+    max_files: 10
+    compress: true
+
+# Metrics (Prometheus compatible)
+metrics:
+  enabled: true
+  endpoint: /metrics
+  prometheus:
+    enabled: true
+    namespace: lumadb
+    include_runtime: true

--- a/anti-call-masking/docker-compose.yml
+++ b/anti-call-masking/docker-compose.yml
@@ -189,3 +189,94 @@ volumes:
   postgres-data:
   clickhouse-data:
   dragonfly-data:
+  lumadb-data:
+  lumadb-wal:
+
+  # =============================================================================
+  # OPTIONAL: LumaDB Unified Database Platform
+  # =============================================================================
+  # LumaDB provides a unified database replacing kdb+, Kafka, Redis, PostgreSQL
+  # in a single 7.7MB binary with:
+  #   - PostgreSQL wire protocol (port 5432)
+  #   - Kafka-compatible streaming (port 9092)
+  #   - REST API (port 8080), GraphQL (port 4000), gRPC (port 50051)
+  #   - Built-in Prometheus metrics (port 9090)
+  #
+  # To use LumaDB instead of the default stack:
+  #   docker-compose --profile lumadb up -d
+  # =============================================================================
+
+  # LumaDB - Unified Database Platform (Optional)
+  lumadb:
+    image: ghcr.io/abiolaogu/lumadb:latest
+    container_name: lumadb
+    hostname: lumadb
+    ports:
+      - "5433:5432" # PostgreSQL protocol (offset to avoid conflict)
+      - "9093:9092" # Kafka protocol (offset)
+      - "8081:8080" # REST API (offset)
+      - "4000:4000" # GraphQL API
+      - "50051:50051" # gRPC
+      - "9094:9090" # Prometheus metrics (offset)
+    volumes:
+      - lumadb-data:/data
+      - lumadb-wal:/wal
+      - ./config/lumadb.yaml:/etc/lumadb/config.yaml:ro
+    environment:
+      - LUMADB_NODE_ID=1
+      - LUMADB_DATA_DIR=/data
+      - LUMADB_LOG_DIR=/var/log/lumadb
+      - LUMADB_REST_PORT=8080
+      - LUMADB_GRPC_PORT=50051
+      - LUMADB_KAFKA_PORT=9092
+      - LUMADB_AUTH_ENABLED=false
+      - RUST_LOG=info
+    networks:
+      - voip-network
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8080/health" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    profiles:
+      - lumadb
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '4'
+          memory: 8G
+        reservations:
+          cpus: '2'
+          memory: 4G
+
+  # ACM Detection Service using LumaDB (Optional)
+  acm-detection-lumadb:
+    build:
+      context: ./lumadb
+      dockerfile: Dockerfile
+    container_name: acm-detection-lumadb
+    hostname: acm-detection-lumadb
+    ports:
+      - "5001:5001"
+    environment:
+      - LUMADB_REST_HOST=lumadb
+      - LUMADB_REST_PORT=8080
+      - LUMADB_PG_HOST=lumadb
+      - LUMADB_PG_PORT=5432
+      - LUMADB_PG_USER=lumadb
+      - LUMADB_PG_PASSWORD=lumadb
+      - LUMADB_PG_DATABASE=default
+      - LUMADB_KAFKA_HOST=lumadb
+      - LUMADB_KAFKA_PORT=9092
+      - DETECTION_WINDOW_SECONDS=5
+      - DETECTION_THRESHOLD=5
+      - LOG_LEVEL=INFO
+    networks:
+      - voip-network
+    depends_on:
+      - lumadb
+    profiles:
+      - lumadb
+    restart: unless-stopped

--- a/anti-call-masking/lumadb/Dockerfile
+++ b/anti-call-masking/lumadb/Dockerfile
@@ -1,0 +1,40 @@
+# Anti-Call Masking Detection System - LumaDB Edition
+# Python-based detection service
+
+FROM python:3.11-slim
+
+# Set working directory
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    gcc \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy requirements first for better caching
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY *.py .
+
+# Create non-root user
+RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app
+USER appuser
+
+# Environment variables
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV LOG_LEVEL=INFO
+ENV API_PORT=5001
+
+# Expose API port
+EXPOSE 5001
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD python -c "import httpx; httpx.get('http://localhost:5001/health')" || exit 1
+
+# Run the API server
+CMD ["python", "api.py"]

--- a/anti-call-masking/lumadb/api.py
+++ b/anti-call-masking/lumadb/api.py
@@ -1,0 +1,350 @@
+"""
+Anti-Call Masking Detection System - LumaDB Edition
+FastAPI HTTP Server replacing kdb+ HTTP server
+"""
+
+from contextlib import asynccontextmanager
+from datetime import datetime
+from typing import List, Optional
+import structlog
+from fastapi import FastAPI, HTTPException, Query, BackgroundTasks
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+from prometheus_client import Counter, Histogram, generate_latest, CONTENT_TYPE_LATEST
+from starlette.responses import Response
+
+from config import settings
+from models import (
+    CallEvent, FraudAlert, AlertStatus, ThreatLevel, DetectionResult
+)
+from database import db
+from detection import engine
+
+logger = structlog.get_logger()
+
+# Prometheus metrics
+CALLS_PROCESSED = Counter(
+    'acm_calls_processed_total',
+    'Total number of calls processed'
+)
+ALERTS_GENERATED = Counter(
+    'acm_alerts_generated_total',
+    'Total number of fraud alerts generated',
+    ['severity']
+)
+DETECTION_LATENCY = Histogram(
+    'acm_detection_latency_seconds',
+    'Call detection latency in seconds',
+    buckets=[.0001, .0005, .001, .005, .01, .025, .05, .1, .25, .5, 1.0]
+)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Application lifespan handler"""
+    # Startup
+    logger.info("Starting Anti-Call Masking Detection System (LumaDB Edition)")
+    await db.initialize()
+    yield
+    # Shutdown
+    await db.close()
+    logger.info("Shutdown complete")
+
+
+app = FastAPI(
+    title="Anti-Call Masking Detection System",
+    description="Real-time fraud detection using LumaDB time-series analytics",
+    version="2.0.0",
+    lifespan=lifespan
+)
+
+# CORS middleware
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.api.cors_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+# =========================================================================
+# Health & Status Endpoints
+# =========================================================================
+
+@app.get("/health")
+async def health_check():
+    """Health check endpoint"""
+    try:
+        stats = await db.get_stats()
+        return {
+            "status": "healthy",
+            "timestamp": datetime.utcnow().isoformat(),
+            "version": settings.app_version,
+            "database": "connected",
+            "stats": stats
+        }
+    except Exception as e:
+        raise HTTPException(status_code=503, detail=str(e))
+
+
+@app.get("/")
+async def root():
+    """Root endpoint"""
+    return {
+        "name": settings.app_name,
+        "version": settings.app_version,
+        "description": "Anti-Call Masking Detection System powered by LumaDB",
+        "endpoints": {
+            "health": "/health",
+            "call": "POST /acm/call",
+            "alerts": "GET /acm/alerts",
+            "threat": "GET /acm/threat",
+            "stats": "GET /acm/stats"
+        }
+    }
+
+
+# =========================================================================
+# Call Processing Endpoints (replacing kdb+ IPC)
+# =========================================================================
+
+class CallEventRequest(BaseModel):
+    """Request model for call event"""
+    a_number: str
+    b_number: str
+    source_ip: Optional[str] = None
+    switch_id: Optional[str] = None
+    call_id: Optional[str] = None
+    raw_call_id: Optional[str] = None
+
+
+class BatchCallRequest(BaseModel):
+    """Request model for batch call events"""
+    events: List[CallEventRequest]
+
+
+@app.post("/acm/call", response_model=DetectionResult)
+async def process_call(request: CallEventRequest, background_tasks: BackgroundTasks):
+    """
+    Process a single call event for fraud detection.
+
+    This endpoint accepts call events from voice switches and
+    checks for multicall masking attacks in real-time.
+    """
+    event = CallEvent(
+        a_number=request.a_number,
+        b_number=request.b_number,
+        source_ip=request.source_ip,
+        switch_id=request.switch_id,
+        call_id=request.call_id,
+        raw_call_id=request.raw_call_id
+    )
+
+    with DETECTION_LATENCY.time():
+        result = await engine.process_call(event)
+
+    CALLS_PROCESSED.inc()
+    if result.detected and result.alert_id:
+        ALERTS_GENERATED.labels(severity="detected").inc()
+
+    # Background cleanup
+    background_tasks.add_task(db.cleanup_old_records)
+
+    return result
+
+
+@app.post("/acm/calls/batch")
+async def process_call_batch(request: BatchCallRequest, background_tasks: BackgroundTasks):
+    """Process a batch of call events"""
+    events = [
+        CallEvent(
+            a_number=e.a_number,
+            b_number=e.b_number,
+            source_ip=e.source_ip,
+            switch_id=e.switch_id,
+            call_id=e.call_id,
+            raw_call_id=e.raw_call_id
+        )
+        for e in request.events
+    ]
+
+    results = await engine.process_batch(events)
+    CALLS_PROCESSED.inc(len(events))
+
+    detected_count = sum(1 for r in results if r.detected)
+    if detected_count > 0:
+        ALERTS_GENERATED.labels(severity="batch").inc(detected_count)
+
+    background_tasks.add_task(db.cleanup_old_records)
+
+    return {
+        "processed": len(results),
+        "detected": detected_count,
+        "results": results
+    }
+
+
+# Voice-Switch-IM compatible endpoint
+@app.post("/event")
+async def process_event(request: CallEventRequest, background_tasks: BackgroundTasks):
+    """Voice-Switch-IM compatible call event endpoint"""
+    return await process_call(request, background_tasks)
+
+
+@app.post("/events/batch")
+async def process_events_batch(request: BatchCallRequest, background_tasks: BackgroundTasks):
+    """Voice-Switch-IM compatible batch endpoint"""
+    return await process_call_batch(request, background_tasks)
+
+
+# =========================================================================
+# Alert Endpoints
+# =========================================================================
+
+@app.get("/acm/alerts")
+async def get_alerts(minutes: int = Query(60, ge=1, le=10080)):
+    """Get fraud alerts from the last N minutes"""
+    alerts = await db.get_recent_alerts(minutes)
+    return {
+        "count": len(alerts),
+        "minutes": minutes,
+        "alerts": [alert.model_dump() for alert in alerts]
+    }
+
+
+@app.get("/acm/alerts/{alert_id}")
+async def get_alert(alert_id: str):
+    """Get specific alert details"""
+    alert = await db.get_alert(alert_id)
+    if not alert:
+        raise HTTPException(status_code=404, detail="Alert not found")
+    return alert.model_dump()
+
+
+class UpdateAlertRequest(BaseModel):
+    status: AlertStatus
+    notes: Optional[str] = None
+
+
+@app.patch("/acm/alerts/{alert_id}")
+async def update_alert(alert_id: str, request: UpdateAlertRequest):
+    """Update alert status"""
+    success = await db.update_alert_status(alert_id, request.status, request.notes)
+    if not success:
+        raise HTTPException(status_code=404, detail="Alert not found")
+    return {"success": True, "alert_id": alert_id, "new_status": request.status.value}
+
+
+# =========================================================================
+# Threat Level Endpoints
+# =========================================================================
+
+@app.get("/acm/threat")
+async def get_threat_level(b_number: str = Query(..., min_length=1)):
+    """Get current threat level for a B-number"""
+    threat = await db.get_threat_level(b_number)
+    return threat.model_dump()
+
+
+@app.get("/acm/threats")
+async def get_elevated_threats():
+    """Get all B-numbers with elevated threat levels"""
+    threats = await db.get_elevated_threats()
+    return {
+        "count": len(threats),
+        "threats": [t.model_dump() for t in threats]
+    }
+
+
+# =========================================================================
+# Statistics Endpoints
+# =========================================================================
+
+@app.get("/acm/stats")
+async def get_stats():
+    """Get detection statistics"""
+    db_stats = await db.get_stats()
+    engine_stats = engine.get_stats()
+    return {
+        **db_stats,
+        **engine_stats,
+        "timestamp": datetime.utcnow().isoformat()
+    }
+
+
+@app.get("/stats")
+async def get_stats_compat():
+    """Compatibility endpoint for stats"""
+    return await get_stats()
+
+
+# =========================================================================
+# Configuration Endpoints
+# =========================================================================
+
+class ConfigUpdateRequest(BaseModel):
+    threshold: Optional[int] = None
+    window_seconds: Optional[int] = None
+
+
+@app.post("/acm/config")
+async def update_config(request: ConfigUpdateRequest):
+    """Update detection configuration"""
+    results = {}
+
+    if request.threshold is not None:
+        success = await engine.set_threshold(request.threshold)
+        results["threshold"] = {"success": success, "value": request.threshold}
+
+    if request.window_seconds is not None:
+        success = await engine.set_window(request.window_seconds)
+        results["window_seconds"] = {"success": success, "value": request.window_seconds}
+
+    return results
+
+
+@app.get("/acm/config")
+async def get_config():
+    """Get current detection configuration"""
+    return {
+        "window_seconds": settings.detection.window_seconds,
+        "threshold": settings.detection.threshold,
+        "cooldown_seconds": settings.detection.cooldown_seconds,
+        "auto_disconnect": settings.detection.auto_disconnect,
+        "auto_block": settings.detection.auto_block,
+        "block_duration_hours": settings.detection.block_duration_hours
+    }
+
+
+# =========================================================================
+# Prometheus Metrics Endpoint
+# =========================================================================
+
+@app.get("/metrics")
+async def metrics():
+    """Prometheus metrics endpoint"""
+    return Response(
+        content=generate_latest(),
+        media_type=CONTENT_TYPE_LATEST
+    )
+
+
+# =========================================================================
+# Main entry point
+# =========================================================================
+
+def main():
+    """Run the API server"""
+    import uvicorn
+    uvicorn.run(
+        "api:app",
+        host=settings.api.host,
+        port=settings.api.port,
+        workers=settings.api.workers,
+        reload=settings.api.debug
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/anti-call-masking/lumadb/config.py
+++ b/anti-call-masking/lumadb/config.py
@@ -1,0 +1,133 @@
+"""
+Anti-Call Masking Detection System - LumaDB Edition
+Configuration settings using Pydantic
+"""
+
+from pydantic_settings import BaseSettings
+from pydantic import Field
+from typing import Optional, List
+import os
+
+
+class LumaDBSettings(BaseSettings):
+    """LumaDB connection settings - replaces kdb+, Kafka, Redis, and PostgreSQL"""
+
+    # LumaDB REST API
+    rest_host: str = Field(default="localhost", env="LUMADB_REST_HOST")
+    rest_port: int = Field(default=8080, env="LUMADB_REST_PORT")
+
+    # LumaDB PostgreSQL Protocol (SQL queries)
+    pg_host: str = Field(default="localhost", env="LUMADB_PG_HOST")
+    pg_port: int = Field(default=5432, env="LUMADB_PG_PORT")
+    pg_user: str = Field(default="lumadb", env="LUMADB_PG_USER")
+    pg_password: str = Field(default="lumadb", env="LUMADB_PG_PASSWORD")
+    pg_database: str = Field(default="default", env="LUMADB_PG_DATABASE")
+
+    # LumaDB Kafka Protocol (streaming)
+    kafka_host: str = Field(default="localhost", env="LUMADB_KAFKA_HOST")
+    kafka_port: int = Field(default=9092, env="LUMADB_KAFKA_PORT")
+
+    # LumaDB gRPC (high-performance queries)
+    grpc_host: str = Field(default="localhost", env="LUMADB_GRPC_HOST")
+    grpc_port: int = Field(default=50051, env="LUMADB_GRPC_PORT")
+
+    @property
+    def rest_url(self) -> str:
+        return f"http://{self.rest_host}:{self.rest_port}"
+
+    @property
+    def pg_dsn(self) -> str:
+        return f"postgresql://{self.pg_user}:{self.pg_password}@{self.pg_host}:{self.pg_port}/{self.pg_database}"
+
+    @property
+    def kafka_bootstrap_servers(self) -> str:
+        return f"{self.kafka_host}:{self.kafka_port}"
+
+    class Config:
+        env_prefix = "LUMADB_"
+
+
+class DetectionSettings(BaseSettings):
+    """Anti-call masking detection configuration"""
+
+    # Detection window in seconds (5 second sliding window)
+    window_seconds: int = Field(default=5, env="ACM_WINDOW_SECONDS")
+
+    # Minimum distinct A-numbers to trigger alert
+    threshold: int = Field(default=5, env="ACM_THRESHOLD")
+
+    # Cooldown between alerts for same B-number (seconds)
+    cooldown_seconds: int = Field(default=30, env="ACM_COOLDOWN_SECONDS")
+
+    # Auto-disconnect detected fraud calls
+    auto_disconnect: bool = Field(default=False, env="ACM_AUTO_DISCONNECT")
+
+    # Auto-block patterns after detection
+    auto_block: bool = Field(default=True, env="ACM_AUTO_BLOCK")
+
+    # Block duration in hours
+    block_duration_hours: int = Field(default=24, env="ACM_BLOCK_DURATION_HOURS")
+
+    class Config:
+        env_prefix = "ACM_"
+
+
+class APISettings(BaseSettings):
+    """API server configuration"""
+
+    host: str = Field(default="0.0.0.0", env="API_HOST")
+    port: int = Field(default=5001, env="API_PORT")
+    debug: bool = Field(default=False, env="API_DEBUG")
+    workers: int = Field(default=4, env="API_WORKERS")
+
+    # CORS settings
+    cors_origins: List[str] = Field(default=["*"], env="API_CORS_ORIGINS")
+
+    class Config:
+        env_prefix = "API_"
+
+
+class StreamingSettings(BaseSettings):
+    """LumaDB Kafka-compatible streaming settings"""
+
+    # Topic names
+    calls_topic: str = Field(default="acm.calls", env="STREAM_CALLS_TOPIC")
+    alerts_topic: str = Field(default="acm.alerts", env="STREAM_ALERTS_TOPIC")
+    actions_topic: str = Field(default="acm.actions", env="STREAM_ACTIONS_TOPIC")
+
+    # Consumer group
+    consumer_group: str = Field(default="acm-detection", env="STREAM_CONSUMER_GROUP")
+
+    # Batch settings
+    batch_size: int = Field(default=100, env="STREAM_BATCH_SIZE")
+    batch_timeout_ms: int = Field(default=100, env="STREAM_BATCH_TIMEOUT_MS")
+
+    class Config:
+        env_prefix = "STREAM_"
+
+
+class Settings(BaseSettings):
+    """Main application settings"""
+
+    # Sub-configurations
+    lumadb: LumaDBSettings = LumaDBSettings()
+    detection: DetectionSettings = DetectionSettings()
+    api: APISettings = APISettings()
+    streaming: StreamingSettings = StreamingSettings()
+
+    # Application info
+    app_name: str = "Anti-Call Masking Detection System"
+    app_version: str = "2.0.0"
+    environment: str = Field(default="development", env="ENVIRONMENT")
+
+    # Logging
+    log_level: str = Field(default="INFO", env="LOG_LEVEL")
+    log_format: str = Field(default="json", env="LOG_FORMAT")
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+
+# Global settings instance
+settings = Settings()

--- a/anti-call-masking/lumadb/database.py
+++ b/anti-call-masking/lumadb/database.py
@@ -1,0 +1,483 @@
+"""
+Anti-Call Masking Detection System - LumaDB Edition
+LumaDB database client - unified interface replacing kdb+, Kafka, Redis, PostgreSQL
+"""
+
+import asyncio
+import json
+from datetime import datetime, timedelta
+from typing import Optional, List, Dict, Any, AsyncGenerator
+from contextlib import asynccontextmanager
+import structlog
+import asyncpg
+from kafka import KafkaProducer, KafkaConsumer
+import httpx
+
+from config import settings
+from models import (
+    CallRecord, FraudAlert, BlockedPattern, ThreatLevel,
+    AlertSeverity, AlertStatus, LUMADB_SCHEMA, KAFKA_TOPICS
+)
+
+logger = structlog.get_logger()
+
+
+class LumaDBClient:
+    """
+    Unified LumaDB client that provides:
+    - Time-series queries (replacing kdb+)
+    - Streaming via Kafka protocol (replacing Kafka/Redpanda)
+    - SQL queries via PostgreSQL protocol
+    - REST API for management
+    """
+
+    def __init__(self):
+        self.pg_pool: Optional[asyncpg.Pool] = None
+        self.kafka_producer: Optional[KafkaProducer] = None
+        self.http_client: Optional[httpx.AsyncClient] = None
+        self._initialized = False
+
+    async def initialize(self):
+        """Initialize all LumaDB connections"""
+        if self._initialized:
+            return
+
+        logger.info("Initializing LumaDB connections...")
+
+        # Initialize PostgreSQL connection pool (LumaDB supports PostgreSQL wire protocol)
+        try:
+            self.pg_pool = await asyncpg.create_pool(
+                dsn=settings.lumadb.pg_dsn,
+                min_size=5,
+                max_size=20,
+                command_timeout=30.0
+            )
+            logger.info("LumaDB PostgreSQL pool initialized", dsn=settings.lumadb.pg_dsn)
+        except Exception as e:
+            logger.error("Failed to initialize PostgreSQL pool", error=str(e))
+            raise
+
+        # Initialize Kafka producer (LumaDB is 100% Kafka-compatible)
+        try:
+            self.kafka_producer = KafkaProducer(
+                bootstrap_servers=settings.lumadb.kafka_bootstrap_servers,
+                value_serializer=lambda v: json.dumps(v, default=str).encode('utf-8'),
+                key_serializer=lambda k: k.encode('utf-8') if k else None,
+                acks='all',
+                retries=3,
+                batch_size=16384,
+                linger_ms=5
+            )
+            logger.info("LumaDB Kafka producer initialized",
+                       bootstrap_servers=settings.lumadb.kafka_bootstrap_servers)
+        except Exception as e:
+            logger.warning("Failed to initialize Kafka producer", error=str(e))
+            # Continue without Kafka - it's optional for basic operation
+
+        # Initialize HTTP client for REST API
+        self.http_client = httpx.AsyncClient(
+            base_url=settings.lumadb.rest_url,
+            timeout=30.0
+        )
+
+        # Initialize schema
+        await self._init_schema()
+
+        self._initialized = True
+        logger.info("LumaDB client fully initialized")
+
+    async def _init_schema(self):
+        """Initialize database schema"""
+        async with self.pg_pool.acquire() as conn:
+            await conn.execute(LUMADB_SCHEMA)
+            logger.info("Database schema initialized")
+
+    async def close(self):
+        """Close all connections"""
+        if self.pg_pool:
+            await self.pg_pool.close()
+        if self.kafka_producer:
+            self.kafka_producer.close()
+        if self.http_client:
+            await self.http_client.aclose()
+        self._initialized = False
+        logger.info("LumaDB connections closed")
+
+    # =========================================================================
+    # TIME-SERIES OPERATIONS (replacing kdb+)
+    # =========================================================================
+
+    async def insert_call(self, call: CallRecord) -> bool:
+        """Insert a call record into the time-series store"""
+        async with self.pg_pool.acquire() as conn:
+            await conn.execute("""
+                INSERT INTO calls (
+                    call_id, a_number, b_number, timestamp, status,
+                    flagged, alert_id, switch_id, raw_call_id, source_ip
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+                ON CONFLICT (call_id) DO NOTHING
+            """,
+                call.call_id, call.a_number, call.b_number, call.timestamp,
+                call.status.value, call.flagged, call.alert_id,
+                call.switch_id, call.raw_call_id, call.source_ip
+            )
+
+        # Also publish to Kafka topic for streaming consumers
+        if self.kafka_producer:
+            self.kafka_producer.send(
+                settings.streaming.calls_topic,
+                key=call.b_number,
+                value=call.model_dump()
+            )
+
+        return True
+
+    async def get_calls_in_window(
+        self,
+        b_number: str,
+        window_start: datetime,
+        window_end: datetime
+    ) -> List[CallRecord]:
+        """
+        Get calls to a B-number within a time window.
+        This is the core sliding window query - optimized in LumaDB.
+        """
+        async with self.pg_pool.acquire() as conn:
+            rows = await conn.fetch("""
+                SELECT call_id, a_number, b_number, timestamp, status,
+                       flagged, alert_id, switch_id, raw_call_id, source_ip
+                FROM calls
+                WHERE b_number = $1
+                  AND timestamp BETWEEN $2 AND $3
+                  AND flagged = FALSE
+                ORDER BY timestamp DESC
+            """, b_number, window_start, window_end)
+
+            return [
+                CallRecord(
+                    call_id=row['call_id'],
+                    a_number=row['a_number'],
+                    b_number=row['b_number'],
+                    timestamp=row['timestamp'],
+                    status=row['status'],
+                    flagged=row['flagged'],
+                    alert_id=row['alert_id'],
+                    switch_id=row['switch_id'],
+                    raw_call_id=row['raw_call_id'],
+                    source_ip=row['source_ip']
+                )
+                for row in rows
+            ]
+
+    async def count_distinct_a_numbers(
+        self,
+        b_number: str,
+        window_start: datetime,
+        window_end: datetime
+    ) -> int:
+        """Count distinct A-numbers calling a B-number in the window"""
+        async with self.pg_pool.acquire() as conn:
+            count = await conn.fetchval("""
+                SELECT COUNT(DISTINCT a_number)
+                FROM calls
+                WHERE b_number = $1
+                  AND timestamp BETWEEN $2 AND $3
+                  AND flagged = FALSE
+            """, b_number, window_start, window_end)
+            return count or 0
+
+    async def flag_calls(self, call_ids: List[str], alert_id: str) -> int:
+        """Flag calls as part of a fraud alert"""
+        async with self.pg_pool.acquire() as conn:
+            result = await conn.execute("""
+                UPDATE calls
+                SET flagged = TRUE, alert_id = $1
+                WHERE call_id = ANY($2)
+            """, alert_id, call_ids)
+            return int(result.split()[-1])
+
+    # =========================================================================
+    # ALERT OPERATIONS
+    # =========================================================================
+
+    async def create_alert(self, alert: FraudAlert) -> str:
+        """Create a new fraud alert"""
+        async with self.pg_pool.acquire() as conn:
+            await conn.execute("""
+                INSERT INTO fraud_alerts (
+                    alert_id, b_number, a_numbers, call_ids, source_ips,
+                    call_count, window_start, window_end, severity, status,
+                    retry_count, created_at, updated_at, notes
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+            """,
+                alert.alert_id, alert.b_number, alert.a_numbers, alert.call_ids,
+                alert.source_ips, alert.call_count, alert.window_start, alert.window_end,
+                alert.severity.value, alert.status.value, alert.retry_count,
+                alert.created_at, alert.updated_at, alert.notes
+            )
+
+        # Publish to alerts topic
+        if self.kafka_producer:
+            self.kafka_producer.send(
+                settings.streaming.alerts_topic,
+                key=alert.b_number,
+                value=alert.model_dump()
+            )
+
+        return alert.alert_id
+
+    async def get_alert(self, alert_id: str) -> Optional[FraudAlert]:
+        """Get alert by ID"""
+        async with self.pg_pool.acquire() as conn:
+            row = await conn.fetchrow("""
+                SELECT * FROM fraud_alerts WHERE alert_id = $1
+            """, alert_id)
+            if row:
+                return FraudAlert(**dict(row))
+            return None
+
+    async def get_recent_alerts(self, minutes: int = 60) -> List[FraudAlert]:
+        """Get alerts from the last N minutes"""
+        cutoff = datetime.utcnow() - timedelta(minutes=minutes)
+        async with self.pg_pool.acquire() as conn:
+            rows = await conn.fetch("""
+                SELECT * FROM fraud_alerts
+                WHERE created_at > $1
+                ORDER BY created_at DESC
+            """, cutoff)
+            return [FraudAlert(**dict(row)) for row in rows]
+
+    async def update_alert_status(
+        self,
+        alert_id: str,
+        status: AlertStatus,
+        notes: Optional[str] = None
+    ) -> bool:
+        """Update alert status"""
+        async with self.pg_pool.acquire() as conn:
+            result = await conn.execute("""
+                UPDATE fraud_alerts
+                SET status = $1, updated_at = $2, notes = COALESCE($3, notes),
+                    resolved_at = CASE WHEN $1 IN ('RESOLVED', 'FALSE_POSITIVE') THEN $2 ELSE resolved_at END
+                WHERE alert_id = $4
+            """, status.value, datetime.utcnow(), notes, alert_id)
+            return "UPDATE 1" in result
+
+    # =========================================================================
+    # COOLDOWN OPERATIONS
+    # =========================================================================
+
+    async def is_in_cooldown(self, b_number: str) -> bool:
+        """Check if B-number is in cooldown period"""
+        cooldown_cutoff = datetime.utcnow() - timedelta(seconds=settings.detection.cooldown_seconds)
+        async with self.pg_pool.acquire() as conn:
+            row = await conn.fetchrow("""
+                SELECT last_alert_at FROM cooldowns
+                WHERE b_number = $1 AND last_alert_at > $2
+            """, b_number, cooldown_cutoff)
+            return row is not None
+
+    async def set_cooldown(self, b_number: str):
+        """Set cooldown for a B-number"""
+        async with self.pg_pool.acquire() as conn:
+            await conn.execute("""
+                INSERT INTO cooldowns (b_number, last_alert_at, alert_count)
+                VALUES ($1, $2, 1)
+                ON CONFLICT (b_number) DO UPDATE
+                SET last_alert_at = $2, alert_count = cooldowns.alert_count + 1
+            """, b_number, datetime.utcnow())
+
+    # =========================================================================
+    # BLOCKED PATTERNS
+    # =========================================================================
+
+    async def is_blocked(self, b_number: str, a_number: str) -> bool:
+        """Check if A-number is blocked for this B-number"""
+        async with self.pg_pool.acquire() as conn:
+            row = await conn.fetchrow("""
+                SELECT 1 FROM blocked_patterns
+                WHERE b_number = $1
+                  AND $2 = ANY(a_numbers)
+                  AND active = TRUE
+                  AND expires_at > NOW()
+            """, b_number, a_number)
+            return row is not None
+
+    async def create_block(self, block: BlockedPattern):
+        """Create a blocked pattern"""
+        async with self.pg_pool.acquire() as conn:
+            await conn.execute("""
+                INSERT INTO blocked_patterns (
+                    pattern_id, b_number, a_numbers, alert_id,
+                    blocked_at, expires_at, active, reason
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            """,
+                block.pattern_id, block.b_number, block.a_numbers,
+                block.alert_id, block.blocked_at, block.expires_at,
+                block.active, block.reason
+            )
+
+    # =========================================================================
+    # WHITELIST OPERATIONS
+    # =========================================================================
+
+    async def is_whitelisted(self, b_number: str, a_number: str) -> bool:
+        """Check if the pattern is whitelisted"""
+        async with self.pg_pool.acquire() as conn:
+            # Check B-number whitelist
+            row = await conn.fetchrow("""
+                SELECT 1 FROM whitelist
+                WHERE (pattern_type = 'b_number' AND pattern = $1)
+                   OR (pattern_type = 'a_number_prefix' AND $2 LIKE pattern || '%')
+            """, b_number, a_number)
+            return row is not None
+
+    # =========================================================================
+    # THREAT LEVEL QUERIES
+    # =========================================================================
+
+    async def get_threat_level(self, b_number: str) -> ThreatLevel:
+        """Get current threat level for a B-number"""
+        window_start = datetime.utcnow() - timedelta(seconds=settings.detection.window_seconds)
+
+        async with self.pg_pool.acquire() as conn:
+            row = await conn.fetchrow("""
+                SELECT
+                    COUNT(DISTINCT a_number) as distinct_a,
+                    COUNT(DISTINCT source_ip) as distinct_ips,
+                    COUNT(*) as call_count,
+                    MAX(timestamp) as last_seen
+                FROM calls
+                WHERE b_number = $1
+                  AND timestamp > $2
+                  AND status IN ('active', 'ringing')
+            """, b_number, window_start)
+
+            distinct_a = row['distinct_a'] or 0
+            threshold = settings.detection.threshold
+
+            if distinct_a >= threshold:
+                level = "critical"
+            elif distinct_a >= threshold - 1:
+                level = "high"
+            elif distinct_a >= threshold - 2:
+                level = "medium"
+            else:
+                level = "low"
+
+            return ThreatLevel(
+                b_number=b_number,
+                threat_level=level,
+                distinct_a_numbers=distinct_a,
+                distinct_ips=row['distinct_ips'] or 0,
+                call_count=row['call_count'] or 0,
+                last_seen=row['last_seen'] or datetime.utcnow()
+            )
+
+    async def get_elevated_threats(self) -> List[ThreatLevel]:
+        """Get all B-numbers with elevated threat levels"""
+        window_start = datetime.utcnow() - timedelta(seconds=settings.detection.window_seconds)
+        min_threshold = settings.detection.threshold - 2
+
+        async with self.pg_pool.acquire() as conn:
+            rows = await conn.fetch("""
+                SELECT
+                    b_number,
+                    COUNT(DISTINCT a_number) as distinct_a,
+                    COUNT(DISTINCT source_ip) as distinct_ips,
+                    COUNT(*) as call_count,
+                    MAX(timestamp) as last_seen
+                FROM calls
+                WHERE timestamp > $1
+                  AND status IN ('active', 'ringing')
+                GROUP BY b_number
+                HAVING COUNT(DISTINCT a_number) >= $2
+                ORDER BY distinct_a DESC
+            """, window_start, min_threshold)
+
+            threats = []
+            threshold = settings.detection.threshold
+            for row in rows:
+                distinct_a = row['distinct_a']
+                if distinct_a >= threshold:
+                    level = "critical"
+                elif distinct_a >= threshold - 1:
+                    level = "high"
+                else:
+                    level = "medium"
+
+                threats.append(ThreatLevel(
+                    b_number=row['b_number'],
+                    threat_level=level,
+                    distinct_a_numbers=distinct_a,
+                    distinct_ips=row['distinct_ips'],
+                    call_count=row['call_count'],
+                    last_seen=row['last_seen']
+                ))
+
+            return threats
+
+    # =========================================================================
+    # STATISTICS
+    # =========================================================================
+
+    async def get_stats(self) -> Dict[str, Any]:
+        """Get detection statistics"""
+        window_start = datetime.utcnow() - timedelta(seconds=settings.detection.window_seconds)
+
+        async with self.pg_pool.acquire() as conn:
+            # Get active calls count
+            active_calls = await conn.fetchval("""
+                SELECT COUNT(*) FROM calls
+                WHERE timestamp > $1 AND status IN ('active', 'ringing')
+            """, window_start)
+
+            # Get total counts
+            total_calls = await conn.fetchval("SELECT COUNT(*) FROM calls")
+            total_alerts = await conn.fetchval("SELECT COUNT(*) FROM fraud_alerts")
+
+            # Get alert counts by severity
+            alert_counts = await conn.fetch("""
+                SELECT severity, COUNT(*) as count
+                FROM fraud_alerts
+                WHERE created_at > NOW() - INTERVAL '24 hours'
+                GROUP BY severity
+            """)
+
+            return {
+                "total_calls": total_calls or 0,
+                "total_alerts": total_alerts or 0,
+                "active_calls": active_calls or 0,
+                "alerts_by_severity": {row['severity']: row['count'] for row in alert_counts},
+                "window_seconds": settings.detection.window_seconds,
+                "threshold": settings.detection.threshold
+            }
+
+    # =========================================================================
+    # CLEANUP / MAINTENANCE
+    # =========================================================================
+
+    async def cleanup_old_records(self, retention_seconds: int = 300):
+        """Clean up old unflagged call records"""
+        cutoff = datetime.utcnow() - timedelta(seconds=retention_seconds)
+        async with self.pg_pool.acquire() as conn:
+            result = await conn.execute("""
+                DELETE FROM calls
+                WHERE timestamp < $1 AND flagged = FALSE
+            """, cutoff)
+            deleted = int(result.split()[-1])
+            if deleted > 0:
+                logger.info("Cleaned up old records", count=deleted)
+
+    async def expire_blocks(self):
+        """Expire old blocked patterns"""
+        async with self.pg_pool.acquire() as conn:
+            await conn.execute("""
+                UPDATE blocked_patterns
+                SET active = FALSE
+                WHERE expires_at < NOW() AND active = TRUE
+            """)
+
+
+# Global database client instance
+db = LumaDBClient()

--- a/anti-call-masking/lumadb/detection.py
+++ b/anti-call-masking/lumadb/detection.py
@@ -1,0 +1,271 @@
+"""
+Anti-Call Masking Detection System - LumaDB Edition
+Core detection engine using LumaDB for time-series analysis
+"""
+
+import time
+from datetime import datetime, timedelta
+from typing import Optional, List, Tuple
+import structlog
+import uuid
+import re
+
+from config import settings
+from models import (
+    CallEvent, CallRecord, FraudAlert, BlockedPattern,
+    DetectionResult, AlertSeverity, AlertStatus, CallStatus
+)
+from database import db
+
+logger = structlog.get_logger()
+
+
+class DetectionEngine:
+    """
+    Anti-Call Masking Detection Engine using LumaDB.
+
+    Detects multicall masking attacks by identifying when 5+ distinct
+    A-numbers call the same B-number within a 5-second sliding window.
+
+    Replaces kdb+ detection logic with LumaDB SQL queries.
+    """
+
+    def __init__(self):
+        self.processed_count = 0
+        self.alert_count = 0
+        self.latencies: List[float] = []
+
+    @staticmethod
+    def normalize_number(number: str) -> str:
+        """Normalize phone number by removing formatting characters"""
+        if not number:
+            return ""
+        # Remove common formatting
+        normalized = re.sub(r'[\s\-\(\)\.]', '', str(number))
+        return normalized
+
+    def _calculate_severity(self, distinct_count: int) -> AlertSeverity:
+        """Calculate alert severity based on distinct A-number count"""
+        if distinct_count >= settings.detection.threshold + 5:
+            return AlertSeverity.CRITICAL
+        elif distinct_count >= settings.detection.threshold + 2:
+            return AlertSeverity.HIGH
+        elif distinct_count >= settings.detection.threshold:
+            return AlertSeverity.MEDIUM
+        return AlertSeverity.LOW
+
+    async def process_call(self, event: CallEvent) -> DetectionResult:
+        """
+        Process an incoming call event and check for masking attack.
+
+        This is the main entry point for call processing.
+        Implements the same logic as the kdb+ detection.q but using LumaDB.
+        """
+        start_time = time.perf_counter()
+
+        try:
+            # Normalize phone numbers
+            a_number = self.normalize_number(event.a_number)
+            b_number = self.normalize_number(event.b_number)
+
+            if not a_number or not b_number:
+                return DetectionResult(
+                    detected=False,
+                    message="Invalid phone numbers"
+                )
+
+            # Check whitelist
+            if await db.is_whitelisted(b_number, a_number):
+                return DetectionResult(
+                    detected=False,
+                    message="Pattern is whitelisted"
+                )
+
+            # Check if pattern is blocked
+            if await db.is_blocked(b_number, a_number):
+                return DetectionResult(
+                    detected=True,
+                    message="Pattern is blocked - call rejected"
+                )
+
+            # Create call record
+            call = CallRecord(
+                call_id=event.call_id or str(uuid.uuid4()),
+                a_number=a_number,
+                b_number=b_number,
+                timestamp=event.timestamp or datetime.utcnow(),
+                status=CallStatus.ACTIVE,
+                flagged=False,
+                switch_id=event.switch_id or "default",
+                raw_call_id=event.raw_call_id,
+                source_ip=event.source_ip
+            )
+
+            # Insert call into LumaDB
+            await db.insert_call(call)
+
+            # Check for masking attack
+            is_masking, involved_a_numbers, source_ips = await self._check_masking(
+                b_number, call.timestamp
+            )
+
+            alert_id = None
+            if is_masking:
+                # Check cooldown to avoid duplicate alerts
+                if not await db.is_in_cooldown(b_number):
+                    alert_id = await self._create_alert(
+                        b_number, involved_a_numbers, source_ips, call.timestamp
+                    )
+                    self.alert_count += 1
+
+            # Calculate latency
+            latency_ms = (time.perf_counter() - start_time) * 1000
+            self.latencies.append(latency_ms)
+            if len(self.latencies) > 100:
+                self.latencies = self.latencies[-100:]
+
+            self.processed_count += 1
+
+            return DetectionResult(
+                detected=is_masking,
+                alert_id=alert_id,
+                latency_ms=latency_ms,
+                message="Masking attack detected" if is_masking else "Call processed normally"
+            )
+
+        except Exception as e:
+            logger.error("Error processing call", error=str(e), event=event.model_dump())
+            return DetectionResult(
+                detected=False,
+                message=f"Error: {str(e)}"
+            )
+
+    async def _check_masking(
+        self,
+        b_number: str,
+        current_ts: datetime
+    ) -> Tuple[bool, List[str], List[str]]:
+        """
+        Check if a B-number is under masking attack.
+
+        Uses LumaDB's SQL query to count distinct A-numbers in the sliding window.
+        This replaces the kdb+ checkMasking function.
+        """
+        window_seconds = settings.detection.window_seconds
+        window_start = current_ts - timedelta(seconds=window_seconds)
+
+        # Get calls in window
+        calls = await db.get_calls_in_window(b_number, window_start, current_ts)
+
+        # Get distinct A-numbers
+        distinct_a_numbers = list(set(call.a_number for call in calls))
+
+        # Get distinct source IPs
+        distinct_ips = list(set(
+            call.source_ip for call in calls
+            if call.source_ip
+        ))
+
+        # Check threshold
+        is_masking = len(distinct_a_numbers) >= settings.detection.threshold
+
+        return is_masking, distinct_a_numbers, distinct_ips
+
+    async def _create_alert(
+        self,
+        b_number: str,
+        involved_a_numbers: List[str],
+        source_ips: List[str],
+        detection_time: datetime
+    ) -> str:
+        """Create a fraud alert and flag associated calls"""
+        window_start = detection_time - timedelta(seconds=settings.detection.window_seconds)
+
+        # Get calls to flag
+        calls = await db.get_calls_in_window(b_number, window_start, detection_time)
+        calls_to_flag = [c for c in calls if c.a_number in involved_a_numbers]
+        call_ids = [c.call_id for c in calls_to_flag]
+
+        # Calculate severity
+        severity = self._calculate_severity(len(involved_a_numbers))
+
+        # Create alert
+        alert = FraudAlert(
+            alert_id=str(uuid.uuid4()),
+            b_number=b_number,
+            a_numbers=involved_a_numbers,
+            call_ids=call_ids,
+            source_ips=source_ips,
+            call_count=len(calls_to_flag),
+            window_start=window_start,
+            window_end=detection_time,
+            severity=severity,
+            status=AlertStatus.NEW
+        )
+
+        alert_id = await db.create_alert(alert)
+
+        # Flag the calls
+        await db.flag_calls(call_ids, alert_id)
+
+        # Set cooldown
+        await db.set_cooldown(b_number)
+
+        # Auto-block if enabled
+        if settings.detection.auto_block:
+            block = BlockedPattern(
+                b_number=b_number,
+                a_numbers=involved_a_numbers,
+                alert_id=alert_id,
+                expires_at=datetime.utcnow() + timedelta(hours=settings.detection.block_duration_hours)
+            )
+            await db.create_block(block)
+
+        logger.warning(
+            "Masking attack detected",
+            alert_id=alert_id,
+            b_number=b_number,
+            distinct_a_numbers=len(involved_a_numbers),
+            severity=severity.value
+        )
+
+        return alert_id
+
+    async def process_batch(self, events: List[CallEvent]) -> List[DetectionResult]:
+        """Process a batch of call events"""
+        results = []
+        for event in events:
+            result = await self.process_call(event)
+            results.append(result)
+        return results
+
+    def get_stats(self) -> dict:
+        """Get detection statistics"""
+        return {
+            "processed_count": self.processed_count,
+            "alert_count": self.alert_count,
+            "avg_latency_ms": sum(self.latencies) / len(self.latencies) if self.latencies else 0,
+            "max_latency_ms": max(self.latencies) if self.latencies else 0,
+            "window_seconds": settings.detection.window_seconds,
+            "threshold": settings.detection.threshold
+        }
+
+    async def set_threshold(self, threshold: int) -> bool:
+        """Update detection threshold"""
+        if not 2 <= threshold <= 100:
+            return False
+        settings.detection.threshold = threshold
+        logger.info("Detection threshold updated", threshold=threshold)
+        return True
+
+    async def set_window(self, seconds: int) -> bool:
+        """Update detection window"""
+        if not 1 <= seconds <= 60:
+            return False
+        settings.detection.window_seconds = seconds
+        logger.info("Detection window updated", seconds=seconds)
+        return True
+
+
+# Global detection engine instance
+engine = DetectionEngine()

--- a/anti-call-masking/lumadb/models.py
+++ b/anti-call-masking/lumadb/models.py
@@ -1,0 +1,229 @@
+"""
+Anti-Call Masking Detection System - LumaDB Edition
+Database models and schema initialization
+"""
+
+from datetime import datetime, timedelta
+from typing import Optional, List, Dict, Any
+from pydantic import BaseModel, Field
+from enum import Enum
+import uuid
+
+
+class CallStatus(str, Enum):
+    """Call status enumeration"""
+    ACTIVE = "active"
+    RINGING = "ringing"
+    ANSWERED = "answered"
+    ENDED = "ended"
+    DISCONNECTED = "disconnected"
+
+
+class AlertSeverity(str, Enum):
+    """Alert severity levels"""
+    CRITICAL = "CRITICAL"
+    HIGH = "HIGH"
+    MEDIUM = "MEDIUM"
+    LOW = "LOW"
+
+
+class AlertStatus(str, Enum):
+    """Alert status"""
+    NEW = "NEW"
+    INVESTIGATING = "INVESTIGATING"
+    RESOLVED = "RESOLVED"
+    FALSE_POSITIVE = "FALSE_POSITIVE"
+
+
+class CallEvent(BaseModel):
+    """Incoming call event model"""
+    call_id: Optional[str] = Field(default_factory=lambda: str(uuid.uuid4()))
+    a_number: str = Field(..., description="Calling party number (A-number)")
+    b_number: str = Field(..., description="Called party number (B-number)")
+    source_ip: Optional[str] = Field(default=None, description="Source IP address")
+    switch_id: Optional[str] = Field(default="default", description="Voice switch identifier")
+    timestamp: Optional[datetime] = Field(default_factory=datetime.utcnow)
+    raw_call_id: Optional[str] = Field(default=None, description="Raw call ID from switch")
+    metadata: Optional[Dict[str, Any]] = Field(default_factory=dict)
+
+
+class CallRecord(BaseModel):
+    """Call record stored in LumaDB"""
+    call_id: str
+    a_number: str
+    b_number: str
+    timestamp: datetime
+    status: CallStatus = CallStatus.ACTIVE
+    flagged: bool = False
+    alert_id: Optional[str] = None
+    switch_id: str = "default"
+    raw_call_id: Optional[str] = None
+    source_ip: Optional[str] = None
+
+
+class FraudAlert(BaseModel):
+    """Fraud alert model"""
+    alert_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    b_number: str
+    a_numbers: List[str]
+    call_ids: List[str]
+    call_count: int
+    window_start: datetime
+    window_end: datetime
+    severity: AlertSeverity
+    status: AlertStatus = AlertStatus.NEW
+    source_ips: List[str] = Field(default_factory=list)
+    retry_count: int = 0
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    resolved_at: Optional[datetime] = None
+    assigned_to: Optional[str] = None
+    notes: Optional[str] = None
+
+
+class ThreatLevel(BaseModel):
+    """Threat level for a B-number"""
+    b_number: str
+    threat_level: str
+    distinct_a_numbers: int
+    distinct_ips: int
+    call_count: int
+    last_seen: datetime
+
+
+class BlockedPattern(BaseModel):
+    """Blocked number pattern"""
+    pattern_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    b_number: str
+    a_numbers: List[str]
+    alert_id: str
+    blocked_at: datetime = Field(default_factory=datetime.utcnow)
+    expires_at: datetime
+    active: bool = True
+    reason: str = "Auto-blocked due to masking detection"
+
+
+class DetectionResult(BaseModel):
+    """Result of call processing"""
+    detected: bool
+    alert_id: Optional[str] = None
+    latency_ms: float = 0.0
+    message: str = ""
+
+
+# SQL Schema for LumaDB (PostgreSQL-compatible)
+LUMADB_SCHEMA = """
+-- Calls table - time-series optimized
+CREATE TABLE IF NOT EXISTS calls (
+    call_id TEXT PRIMARY KEY,
+    a_number TEXT NOT NULL,
+    b_number TEXT NOT NULL,
+    timestamp TIMESTAMP NOT NULL DEFAULT NOW(),
+    status TEXT NOT NULL DEFAULT 'active',
+    flagged BOOLEAN NOT NULL DEFAULT FALSE,
+    alert_id TEXT,
+    switch_id TEXT DEFAULT 'default',
+    raw_call_id TEXT,
+    source_ip TEXT
+);
+
+-- Create index for sliding window queries (time-series optimized)
+CREATE INDEX IF NOT EXISTS idx_calls_b_number_ts ON calls (b_number, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_calls_timestamp ON calls (timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_calls_alert ON calls (alert_id) WHERE alert_id IS NOT NULL;
+
+-- Fraud alerts table
+CREATE TABLE IF NOT EXISTS fraud_alerts (
+    alert_id TEXT PRIMARY KEY,
+    b_number TEXT NOT NULL,
+    a_numbers TEXT[] NOT NULL,
+    call_ids TEXT[] NOT NULL,
+    source_ips TEXT[] DEFAULT '{}',
+    call_count INTEGER NOT NULL,
+    window_start TIMESTAMP NOT NULL,
+    window_end TIMESTAMP NOT NULL,
+    severity TEXT NOT NULL DEFAULT 'MEDIUM',
+    status TEXT NOT NULL DEFAULT 'NEW',
+    retry_count INTEGER DEFAULT 0,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    resolved_at TIMESTAMP,
+    assigned_to TEXT,
+    notes TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_alerts_status ON fraud_alerts (status);
+CREATE INDEX IF NOT EXISTS idx_alerts_severity ON fraud_alerts (severity);
+CREATE INDEX IF NOT EXISTS idx_alerts_created ON fraud_alerts (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_alerts_b_number ON fraud_alerts (b_number);
+
+-- Blocked patterns table
+CREATE TABLE IF NOT EXISTS blocked_patterns (
+    pattern_id TEXT PRIMARY KEY,
+    b_number TEXT NOT NULL,
+    a_numbers TEXT[] NOT NULL,
+    alert_id TEXT NOT NULL,
+    blocked_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMP NOT NULL,
+    active BOOLEAN NOT NULL DEFAULT TRUE,
+    reason TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_blocked_active ON blocked_patterns (active, expires_at);
+CREATE INDEX IF NOT EXISTS idx_blocked_b_number ON blocked_patterns (b_number);
+
+-- Cooldowns table (for alert rate limiting)
+CREATE TABLE IF NOT EXISTS cooldowns (
+    b_number TEXT PRIMARY KEY,
+    last_alert_at TIMESTAMP NOT NULL,
+    alert_count INTEGER DEFAULT 1
+);
+
+-- Whitelist table
+CREATE TABLE IF NOT EXISTS whitelist (
+    id TEXT PRIMARY KEY,
+    pattern_type TEXT NOT NULL,  -- 'b_number', 'a_number_prefix', 'ip_range'
+    pattern TEXT NOT NULL,
+    reason TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    created_by TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_whitelist_type ON whitelist (pattern_type);
+
+-- Statistics table (time-series)
+CREATE TABLE IF NOT EXISTS detection_stats (
+    timestamp TIMESTAMP PRIMARY KEY,
+    processed_count BIGINT NOT NULL DEFAULT 0,
+    alert_count INTEGER NOT NULL DEFAULT 0,
+    disconnected_count INTEGER NOT NULL DEFAULT 0,
+    avg_latency_ms FLOAT DEFAULT 0,
+    max_latency_ms FLOAT DEFAULT 0,
+    active_calls INTEGER DEFAULT 0,
+    memory_mb FLOAT DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_stats_ts ON detection_stats (timestamp DESC);
+"""
+
+# Kafka Topics Configuration (LumaDB is Kafka-compatible)
+KAFKA_TOPICS = {
+    "calls": {
+        "name": "acm.calls",
+        "partitions": 3,
+        "replication_factor": 1,
+        "retention_ms": 86400000,  # 24 hours
+    },
+    "alerts": {
+        "name": "acm.alerts",
+        "partitions": 1,
+        "replication_factor": 1,
+        "retention_ms": 604800000,  # 7 days
+    },
+    "actions": {
+        "name": "acm.actions",
+        "partitions": 1,
+        "replication_factor": 1,
+        "retention_ms": 604800000,  # 7 days
+    }
+}

--- a/anti-call-masking/lumadb/requirements.txt
+++ b/anti-call-masking/lumadb/requirements.txt
@@ -1,0 +1,42 @@
+# Anti-Call Masking Detection System - LumaDB Edition
+# requirements.txt
+
+# LumaDB Python Client
+lumadb>=0.1.0
+
+# Web Framework
+fastapi>=0.109.0
+uvicorn[standard]>=0.27.0
+httpx>=0.26.0
+
+# Kafka Client (LumaDB is 100% Kafka-compatible)
+kafka-python>=2.0.2
+
+# PostgreSQL Client (LumaDB supports PostgreSQL wire protocol)
+psycopg2-binary>=2.9.9
+asyncpg>=0.29.0
+
+# Data Processing
+pandas>=2.1.0
+numpy>=1.26.0
+
+# Async Support
+aiohttp>=3.9.0
+asyncio-throttle>=1.0.2
+
+# Configuration
+pydantic>=2.5.0
+pydantic-settings>=2.1.0
+python-dotenv>=1.0.0
+
+# Logging & Monitoring
+structlog>=24.1.0
+prometheus-client>=0.19.0
+
+# Testing
+pytest>=7.4.0
+pytest-asyncio>=0.23.0
+pytest-cov>=4.1.0
+
+# Type hints
+typing_extensions>=4.9.0


### PR DESCRIPTION
## Summary

This PR integrates LumaDB from PR #9 as an **optional, non-disruptive** profile-based deployment that does not affect the existing stack.

## Changes

### Added Files
- `anti-call-masking/config/lumadb.yaml` - LumaDB configuration
- `anti-call-masking/lumadb/` - Python detection service using LumaDB
  - `database.py` - Unified PostgreSQL/Kafka/REST client
  - `detection.py` - Fraud detection engine
  - `api.py` - FastAPI endpoints
  - `models.py` - Data models and schema
  - `Dockerfile` - Container build

### Updated Files
- `docker-compose.yml` - Added LumaDB services under `lumadb` profile

## LumaDB Provides

| Protocol | Port | Description |
|----------|------|-------------|
| PostgreSQL | 5433 | SQL queries (offset from existing) |
| Kafka | 9093 | Streaming (offset) |
| REST API | 8081 | HTTP API (offset) |
| GraphQL | 4000 | GraphQL API |
| gRPC | 50051 | gRPC |
| Prometheus | 9094 | Metrics (offset) |

## Usage

```bash
# Use LumaDB stack (optional)
docker-compose --profile lumadb up -d

# Use default stack (unchanged)
docker-compose up -d
```

## Non-Disruptive Integration

- ✅ Default Rust detection service + ClickHouse + DragonflyDB stack **unchanged**
- ✅ Existing `sip-processor` with Redis + PostgreSQL **unchanged**
- ✅ LumaDB added as **optional profile** only
- ✅ Port conflicts avoided with offset ports

Resolves #9