### PR TITLE
feat: Figma Make Prompts design gaps — brand tokens, fonts, AIDD badges, notifications

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -7,9 +7,9 @@
     <meta name="description" content="VoxGuard - Voice Network Fraud Detection Platform" />
     <meta name="theme-color" content="#1e40af" />
     <title>VoxGuard - Voice Fraud Detection</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -49,6 +49,8 @@ import {
   FalsePositivesPage,
 } from './pages/security';
 
+// NCC Compliance Pages
+import { NCCCompliancePage, MNPLookupPage } from './pages/ncc';
 
 // Hooks
 import { useThemeMode } from './hooks/useThemeMode';
@@ -153,6 +155,10 @@ function AppContent() {
                 <Route path="/security/revenue-fraud" element={<RevenueFraudPage />} />
                 <Route path="/security/traffic-control" element={<TrafficControlPage />} />
                 <Route path="/security/false-positives" element={<FalsePositivesPage />} />
+
+                {/* NCC Compliance Pages */}
+                <Route path="/ncc/compliance" element={<NCCCompliancePage />} />
+                <Route path="/ncc/mnp-lookup" element={<MNPLookupPage />} />
 
                 {/* Catch All */}
                 <Route path="*" element={<ErrorComponent />} />

--- a/packages/web/src/components/common/AIDDTierBadge.tsx
+++ b/packages/web/src/components/common/AIDDTierBadge.tsx
@@ -1,0 +1,56 @@
+import { Tag, Tooltip } from 'antd';
+import { LockOutlined, SafetyCertificateOutlined } from '@ant-design/icons';
+
+interface AIDDTierBadgeProps {
+  tier: 0 | 1 | 2;
+  compact?: boolean;
+}
+
+const tierConfig = {
+  0: {
+    color: 'default',
+    label: 'AIDD T0',
+    compactLabel: 'T0',
+    icon: null,
+    tooltip: 'Tier 0 — Auto-merge safe (documentation, tests, text)',
+  },
+  1: {
+    color: 'warning',
+    label: 'AIDD T1',
+    compactLabel: 'T1',
+    icon: <LockOutlined />,
+    tooltip: 'Tier 1 — Requires review (features, logic, blocking actions)',
+  },
+  2: {
+    color: 'error',
+    label: 'AIDD T2',
+    compactLabel: 'T2',
+    icon: <SafetyCertificateOutlined />,
+    tooltip: 'Tier 2 — Requires admin approval (auth, payments, infra)',
+  },
+} as const;
+
+export const AIDDTierBadge: React.FC<AIDDTierBadgeProps> = ({ tier, compact = false }) => {
+  const config = tierConfig[tier];
+
+  return (
+    <Tooltip title={config.tooltip}>
+      <Tag
+        icon={!compact ? config.icon : undefined}
+        color={config.color}
+        style={{
+          fontWeight: 600,
+          fontSize: compact ? 10 : 11,
+          padding: compact ? '0 4px' : '1px 6px',
+          margin: 0,
+          lineHeight: compact ? '18px' : '20px',
+          borderRadius: 10,
+        }}
+      >
+        {compact ? config.compactLabel : config.label}
+      </Tag>
+    </Tooltip>
+  );
+};
+
+export default AIDDTierBadge;

--- a/packages/web/src/components/common/index.ts
+++ b/packages/web/src/components/common/index.ts
@@ -3,3 +3,4 @@ export { SeverityBadge } from './SeverityBadge';
 export { StatusBadge } from './StatusBadge';
 export { LoadingOverlay } from './LoadingOverlay';
 export { ExternalToolsLinks } from './ExternalToolsLinks';
+export { AIDDTierBadge } from './AIDDTierBadge';

--- a/packages/web/src/components/layout/Header.tsx
+++ b/packages/web/src/components/layout/Header.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useGetIdentity, useLogout } from '@refinedev/core';
 import {
   Layout,
@@ -8,6 +9,7 @@ import {
   Badge,
   Button,
   Tooltip,
+  Tag,
 } from 'antd';
 import {
   BellOutlined,
@@ -16,6 +18,10 @@ import {
   LogoutOutlined,
   SunOutlined,
   MoonOutlined,
+  WarningOutlined,
+  FileTextOutlined,
+  SyncOutlined,
+  RightOutlined,
 } from '@ant-design/icons';
 import { useSubscription } from '@apollo/client';
 import { useNavigate } from 'react-router-dom';
@@ -49,6 +55,95 @@ export const Header: React.FC = () => {
     (alertsData?.confirmed_count?.aggregate?.count || 0);
 
   const criticalCount = alertsData?.critical_count?.aggregate?.count || 0;
+
+  const [notificationsOpen, setNotificationsOpen] = useState(false);
+
+  const mockNotifications = [
+    {
+      key: 'n1',
+      icon: <WarningOutlined style={{ color: VG_COLORS.error }} />,
+      title: 'Fraud Alert: Call Masking Detected',
+      description: 'Suspicious CLI spoofing from +234-prefix routes',
+      time: '2 min ago',
+      unread: true,
+    },
+    {
+      key: 'n2',
+      icon: <FileTextOutlined style={{ color: VG_COLORS.info }} />,
+      title: 'NCC Compliance Report Ready',
+      description: 'Monthly NCC submission report generated',
+      time: '15 min ago',
+      unread: true,
+    },
+    {
+      key: 'n3',
+      icon: <SyncOutlined style={{ color: VG_COLORS.success }} />,
+      title: 'System Update Complete',
+      description: 'VoxGuard engine v2.4.1 deployed successfully',
+      time: '1 hr ago',
+      unread: false,
+    },
+    {
+      key: 'n4',
+      icon: <WarningOutlined style={{ color: VG_COLORS.warning }} />,
+      title: 'Wangiri Spike Detected',
+      description: '12 new wangiri incidents from Sierra Leone range',
+      time: '3 hr ago',
+      unread: false,
+    },
+  ];
+
+  const unreadNotifCount = mockNotifications.filter((n) => n.unread).length;
+
+  const notificationMenuItems = [
+    {
+      key: 'notif-header',
+      type: 'group' as const,
+      label: (
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '4px 0' }}>
+          <Text strong style={{ fontSize: 14 }}>Notifications</Text>
+          {unreadNotifCount > 0 && <Tag color="blue">{unreadNotifCount} new</Tag>}
+        </div>
+      ),
+    },
+    { key: 'notif-divider-top', type: 'divider' as const },
+    ...mockNotifications.map((notif) => ({
+      key: notif.key,
+      label: (
+        <div style={{ display: 'flex', gap: 10, alignItems: 'flex-start', padding: '4px 0', maxWidth: 300 }}>
+          <div style={{ fontSize: 16, marginTop: 2 }}>{notif.icon}</div>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <Text strong style={{ fontSize: 13 }}>{notif.title}</Text>
+              {notif.unread && (
+                <span style={{ width: 6, height: 6, borderRadius: '50%', backgroundColor: VG_COLORS.info, display: 'inline-block', flexShrink: 0 }} />
+              )}
+            </div>
+            <Text type="secondary" style={{ fontSize: 11, display: 'block' }}>{notif.description}</Text>
+            <Text type="secondary" style={{ fontSize: 10 }}>{notif.time}</Text>
+          </div>
+        </div>
+      ),
+    })),
+    { key: 'notif-divider-bottom', type: 'divider' as const },
+    {
+      key: 'view-all',
+      label: (
+        <div style={{ textAlign: 'center' }}>
+          <Text type="secondary" style={{ fontSize: 12 }}>
+            View all notifications <RightOutlined style={{ fontSize: 10 }} />
+          </Text>
+        </div>
+      ),
+    },
+  ];
+
+  const handleNotificationClick = ({ key }: { key: string }) => {
+    if (key === 'view-all') {
+      navigate('/alerts');
+      setNotificationsOpen(false);
+    }
+  };
 
   const userMenuItems = [
     {
@@ -113,9 +208,16 @@ export const Header: React.FC = () => {
         <PortalHub />
 
         {/* Notifications */}
-        <Tooltip title={`${unresolvedCount} unresolved alerts`}>
+        <Dropdown
+          menu={{ items: notificationMenuItems, onClick: handleNotificationClick }}
+          trigger={['click']}
+          open={notificationsOpen}
+          onOpenChange={setNotificationsOpen}
+          placement="bottomRight"
+          overlayStyle={{ minWidth: 340 }}
+        >
           <Badge
-            count={unresolvedCount}
+            count={unresolvedCount || unreadNotifCount}
             overflowCount={99}
             style={{
               backgroundColor: criticalCount > 0 ? VG_COLORS.critical : VG_COLORS.warning,
@@ -126,7 +228,7 @@ export const Header: React.FC = () => {
               icon={<BellOutlined style={{ fontSize: 18 }} />}
             />
           </Badge>
-        </Tooltip>
+        </Dropdown>
 
         {/* User Menu */}
         <Dropdown

--- a/packages/web/src/pages/ncc/MNPLookupPage.tsx
+++ b/packages/web/src/pages/ncc/MNPLookupPage.tsx
@@ -1,0 +1,87 @@
+import React, { useState } from 'react';
+import { Card, Table, Tag, Button, Typography, Space, Input, message } from 'antd';
+import { UploadOutlined, SearchOutlined } from '@ant-design/icons';
+import { AIDDTierBadge } from '../../components/common';
+
+const { Title, Text } = Typography;
+
+interface MNPRecord {
+  id: string;
+  msisdn: string;
+  donor_network: string;
+  recipient_network: string;
+  ported_date: string;
+  status: string;
+}
+
+const mockMNPData: MNPRecord[] = [
+  { id: '1', msisdn: '+2348012345678', donor_network: 'MTN Nigeria', recipient_network: 'Airtel Nigeria', ported_date: '2025-04-10', status: 'active' },
+  { id: '2', msisdn: '+2348098765432', donor_network: 'Glo Mobile', recipient_network: 'MTN Nigeria', ported_date: '2025-04-08', status: 'active' },
+  { id: '3', msisdn: '+2349011223344', donor_network: 'Airtel Nigeria', recipient_network: '9mobile', ported_date: '2025-03-25', status: 'pending' },
+  { id: '4', msisdn: '+2348055667788', donor_network: '9mobile', recipient_network: 'Glo Mobile', ported_date: '2025-03-15', status: 'active' },
+];
+
+export const MNPLookupPage: React.FC = () => {
+  const [records] = useState<MNPRecord[]>(mockMNPData);
+  const [searchValue, setSearchValue] = useState('');
+
+  const handleImport = () => {
+    message.success('MNP data import initiated');
+  };
+
+  const filteredRecords = records.filter(
+    (r) =>
+      r.msisdn.includes(searchValue) ||
+      r.donor_network.toLowerCase().includes(searchValue.toLowerCase()) ||
+      r.recipient_network.toLowerCase().includes(searchValue.toLowerCase())
+  );
+
+  const columns = [
+    { title: 'MSISDN', dataIndex: 'msisdn', key: 'msisdn' },
+    { title: 'Donor Network', dataIndex: 'donor_network', key: 'donor_network' },
+    { title: 'Recipient Network', dataIndex: 'recipient_network', key: 'recipient_network' },
+    { title: 'Ported Date', dataIndex: 'ported_date', key: 'ported_date' },
+    {
+      title: 'Status',
+      dataIndex: 'status',
+      key: 'status',
+      render: (status: string) => (
+        <Tag color={status === 'active' ? 'green' : status === 'pending' ? 'orange' : 'default'}>
+          {status.toUpperCase()}
+        </Tag>
+      ),
+    },
+  ];
+
+  return (
+    <div style={{ padding: 24 }}>
+      <Title level={3}>MNP Lookup</Title>
+      <Text type="secondary">Mobile Number Portability database lookup and data import</Text>
+      <div style={{ marginTop: 24 }}>
+        <Card
+          title={`MNP Records (${filteredRecords.length})`}
+          extra={
+            <Space>
+              <Input
+                placeholder="Search MSISDN or network"
+                prefix={<SearchOutlined />}
+                value={searchValue}
+                onChange={(e) => setSearchValue(e.target.value)}
+                style={{ width: 220 }}
+                allowClear
+              />
+              <Button type="primary" icon={<UploadOutlined />} onClick={handleImport}>
+                Import MNP Data
+              </Button>
+              <AIDDTierBadge tier={2} compact />
+            </Space>
+          }
+        >
+          <Table columns={columns} dataSource={filteredRecords} rowKey="id" size="small" />
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default MNPLookupPage;

--- a/packages/web/src/pages/ncc/NCCCompliancePage.tsx
+++ b/packages/web/src/pages/ncc/NCCCompliancePage.tsx
@@ -1,0 +1,146 @@
+import React, { useState } from 'react';
+import { Card, Table, Tag, Button, Typography, Space, message } from 'antd';
+import { SendOutlined, ExclamationCircleOutlined } from '@ant-design/icons';
+import { AIDDTierBadge } from '../../components/common';
+
+const { Title, Text } = Typography;
+
+interface ComplianceReport {
+  id: string;
+  report_type: string;
+  period: string;
+  status: string;
+  submitted_at: string | null;
+  due_date: string;
+  incidents_count: number;
+}
+
+interface Dispute {
+  id: string;
+  reference: string;
+  operator: string;
+  type: string;
+  status: string;
+  amount: number;
+  created_at: string;
+}
+
+const mockReports: ComplianceReport[] = [
+  { id: '1', report_type: 'Monthly Fraud Summary', period: '2025-04', status: 'draft', submitted_at: null, due_date: '2025-05-15', incidents_count: 23 },
+  { id: '2', report_type: 'Quarterly CLI Audit', period: '2025-Q1', status: 'submitted', submitted_at: '2025-04-10', due_date: '2025-04-15', incidents_count: 67 },
+  { id: '3', report_type: 'Monthly Fraud Summary', period: '2025-03', status: 'accepted', submitted_at: '2025-04-05', due_date: '2025-04-15', incidents_count: 19 },
+];
+
+const mockDisputes: Dispute[] = [
+  { id: '1', reference: 'NCC-D-2025-0042', operator: 'MTN Nigeria', type: 'CLI Spoofing', status: 'open', amount: 12500, created_at: '2025-04-20' },
+  { id: '2', reference: 'NCC-D-2025-0039', operator: 'Airtel Nigeria', type: 'Revenue Sharing Fraud', status: 'investigating', amount: 8300, created_at: '2025-04-15' },
+  { id: '3', reference: 'NCC-D-2025-0031', operator: 'Glo Mobile', type: 'Interconnect Bypass', status: 'resolved', amount: 5600, created_at: '2025-03-28' },
+];
+
+export const NCCCompliancePage: React.FC = () => {
+  const [reports] = useState<ComplianceReport[]>(mockReports);
+  const [disputes] = useState<Dispute[]>(mockDisputes);
+
+  const handleSubmit = (id: string) => {
+    message.success(`Report ${id} submitted to NCC`);
+  };
+
+  const handleEscalate = (id: string) => {
+    message.success(`Dispute ${id} escalated`);
+  };
+
+  const statusColor: Record<string, string> = {
+    draft: 'default',
+    submitted: 'blue',
+    accepted: 'green',
+    rejected: 'red',
+    open: 'orange',
+    investigating: 'blue',
+    resolved: 'green',
+  };
+
+  const reportColumns = [
+    { title: 'Report Type', dataIndex: 'report_type', key: 'report_type' },
+    { title: 'Period', dataIndex: 'period', key: 'period' },
+    {
+      title: 'Status',
+      dataIndex: 'status',
+      key: 'status',
+      render: (status: string) => <Tag color={statusColor[status]}>{status.toUpperCase()}</Tag>,
+    },
+    { title: 'Incidents', dataIndex: 'incidents_count', key: 'incidents_count' },
+    { title: 'Due Date', dataIndex: 'due_date', key: 'due_date' },
+    {
+      title: 'Actions',
+      key: 'actions',
+      render: (_: unknown, record: ComplianceReport) =>
+        record.status === 'draft' ? (
+          <Space>
+            <Button
+              type="primary"
+              size="small"
+              icon={<SendOutlined />}
+              onClick={() => handleSubmit(record.id)}
+            >
+              Submit to NCC
+            </Button>
+            <AIDDTierBadge tier={2} compact />
+          </Space>
+        ) : null,
+    },
+  ];
+
+  const disputeColumns = [
+    { title: 'Reference', dataIndex: 'reference', key: 'reference' },
+    { title: 'Operator', dataIndex: 'operator', key: 'operator' },
+    { title: 'Type', dataIndex: 'type', key: 'type' },
+    {
+      title: 'Status',
+      dataIndex: 'status',
+      key: 'status',
+      render: (status: string) => <Tag color={statusColor[status]}>{status.toUpperCase()}</Tag>,
+    },
+    {
+      title: 'Amount',
+      dataIndex: 'amount',
+      key: 'amount',
+      render: (amount: number) => `$${amount.toLocaleString()}`,
+    },
+    {
+      title: 'Actions',
+      key: 'actions',
+      render: (_: unknown, record: Dispute) =>
+        record.status !== 'resolved' ? (
+          <Space>
+            <Button
+              type="primary"
+              danger
+              size="small"
+              icon={<ExclamationCircleOutlined />}
+              onClick={() => handleEscalate(record.id)}
+            >
+              Escalate
+            </Button>
+            <AIDDTierBadge tier={2} compact />
+          </Space>
+        ) : null,
+    },
+  ];
+
+  return (
+    <div style={{ padding: 24 }}>
+      <Title level={3}>NCC Compliance</Title>
+      <Text type="secondary">Nigerian Communications Commission reporting and dispute management</Text>
+      <Space direction="vertical" style={{ width: '100%', marginTop: 24 }} size="large">
+        <Card title={`Compliance Reports (${reports.length})`}>
+          <Table columns={reportColumns} dataSource={reports} rowKey="id" size="small" />
+        </Card>
+        <Card title={`Disputes (${disputes.length})`}>
+          <Table columns={disputeColumns} dataSource={disputes} rowKey="id" size="small" />
+        </Card>
+      </Space>
+    </div>
+  );
+};
+
+export default NCCCompliancePage;

--- a/packages/web/src/pages/ncc/index.ts
+++ b/packages/web/src/pages/ncc/index.ts
@@ -1,0 +1,2 @@
+export { NCCCompliancePage } from './NCCCompliancePage';
+export { MNPLookupPage } from './MNPLookupPage';

--- a/packages/web/src/pages/security/CompositeScoringPage.tsx
+++ b/packages/web/src/pages/security/CompositeScoringPage.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import { Card, Table, Tag, Typography, Space } from 'antd';
+import { Card, Table, Tag, Button, Typography, Space, message } from 'antd';
+import { FilterOutlined } from '@ant-design/icons';
 import { voxguardApi, type CompositeDecision } from '../../api/voxguard';
+import { AIDDTierBadge } from '../../components/common';
 
 const { Title, Text } = Typography;
 
@@ -91,7 +93,21 @@ export const CompositeScoringPage: React.FC = () => {
       <Title level={3}>Composite Scoring</Title>
       <Text type="secondary">Combined VoxGuard and RVS scoring decisions</Text>
       <div style={{ marginTop: 24 }}>
-        <Card title={`Composite Decisions (${decisions.length})`}>
+        <Card
+          title={`Composite Decisions (${decisions.length})`}
+          extra={
+            <Space>
+              <Button
+                type="primary"
+                icon={<FilterOutlined />}
+                onClick={() => message.info('Threshold configuration would open here')}
+              >
+                Apply Threshold
+              </Button>
+              <AIDDTierBadge tier={1} compact />
+            </Space>
+          }
+        >
           <Table
             columns={columns}
             dataSource={decisions}

--- a/packages/web/src/pages/security/ListsManagePage.tsx
+++ b/packages/web/src/pages/security/ListsManagePage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Card, Table, Tag, Button, Tabs, Typography, Space, Modal, Input, message } from 'antd';
 import { PlusOutlined, DeleteOutlined } from '@ant-design/icons';
 import { voxguardApi, type ListEntry } from '../../api/voxguard';
+import { AIDDTierBadge } from '../../components/common';
 
 const { Title, Text } = Typography;
 
@@ -83,14 +84,17 @@ export const ListsManagePage: React.FC = () => {
       title: 'Actions',
       key: 'actions',
       render: (_: unknown, record: ListEntry) => (
-        <Button
-          type="link"
-          danger
-          icon={<DeleteOutlined />}
-          onClick={() => handleDelete(record.id)}
-        >
-          Delete
-        </Button>
+        <Space>
+          <Button
+            type="link"
+            danger
+            icon={<DeleteOutlined />}
+            onClick={() => handleDelete(record.id)}
+          >
+            Delete
+          </Button>
+          <AIDDTierBadge tier={1} compact />
+        </Space>
       ),
     },
   ];
@@ -103,9 +107,12 @@ export const ListsManagePage: React.FC = () => {
         <Card
           title="Blacklist Entries"
           extra={
-            <Button type="primary" icon={<PlusOutlined />} onClick={() => setModalOpen(true)}>
-              Add Entry
-            </Button>
+            <Space>
+              <Button type="primary" icon={<PlusOutlined />} onClick={() => setModalOpen(true)}>
+                Add Entry
+              </Button>
+              <AIDDTierBadge tier={1} compact />
+            </Space>
           }
         >
           <Table
@@ -125,9 +132,12 @@ export const ListsManagePage: React.FC = () => {
         <Card
           title="Whitelist Entries"
           extra={
-            <Button type="primary" icon={<PlusOutlined />} onClick={() => setModalOpen(true)}>
-              Add Entry
-            </Button>
+            <Space>
+              <Button type="primary" icon={<PlusOutlined />} onClick={() => setModalOpen(true)}>
+                Add Entry
+              </Button>
+              <AIDDTierBadge tier={1} compact />
+            </Space>
           }
         >
           <Table

--- a/packages/web/src/pages/security/MultiCallDetectionPage.tsx
+++ b/packages/web/src/pages/security/MultiCallDetectionPage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Card, Table, Tag, Button, Typography, Space, message } from 'antd';
 import { StopOutlined, CheckCircleOutlined } from '@ant-design/icons';
 import { voxguardApi, type MultiCallPattern } from '../../api/voxguard';
+import { AIDDTierBadge } from '../../components/common';
 
 const { Title, Text } = Typography;
 
@@ -92,6 +93,7 @@ export const MultiCallDetectionPage: React.FC = () => {
               >
                 Block
               </Button>
+              <AIDDTierBadge tier={1} compact />
               <Button
                 size="small"
                 icon={<CheckCircleOutlined />}

--- a/packages/web/src/pages/security/RVSDashboardPage.tsx
+++ b/packages/web/src/pages/security/RVSDashboardPage.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import { Card, Row, Col, Statistic, Table, Tag, Badge, Tabs, Switch, Typography, Space, Button } from 'antd';
+import { Card, Row, Col, Statistic, Table, Tag, Tabs, Switch, Typography, Space } from 'antd';
 import { CheckCircleOutlined, ClockCircleOutlined, ThunderboltOutlined, SafetyCertificateOutlined } from '@ant-design/icons';
 import { voxguardApi, type RVSHealth, type VerificationRequest, type FeatureFlag, type MLModelStatus, type DetectionEngineHealth } from '../../api/voxguard';
+import { AIDDTierBadge } from '../../components/common';
 
 const { Title, Text } = Typography;
 
@@ -81,6 +82,7 @@ export const RVSDashboardPage: React.FC = () => {
                 <Space>
                   <Tag>{flag.phase}</Tag>
                   <Switch checked={flag.enabled} onChange={(checked) => voxguardApi.updateFeatureFlag(flag.id, checked)} />
+                  <AIDDTierBadge tier={1} compact />
                 </Space>
               </div>
             ))}

--- a/packages/web/src/pages/security/RevenueFraudPage.tsx
+++ b/packages/web/src/pages/security/RevenueFraudPage.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import { Card, Table, Tag, Button, Tabs, Typography, message } from 'antd';
+import { Card, Table, Tag, Button, Tabs, Typography, Space, message } from 'antd';
 import { StopOutlined } from '@ant-design/icons';
 import { voxguardApi, type WangiriIncident, type IrsfIncident } from '../../api/voxguard';
+import { AIDDTierBadge } from '../../components/common';
 
 const { Title, Text } = Typography;
 
@@ -67,15 +68,18 @@ export const RevenueFraudPage: React.FC = () => {
       key: 'actions',
       render: (_: unknown, record: WangiriIncident) =>
         record.status === 'active' ? (
-          <Button
-            type="primary"
-            danger
-            size="small"
-            icon={<StopOutlined />}
-            onClick={() => handleBlockWangiri(record.id)}
-          >
-            Block
-          </Button>
+          <Space>
+            <Button
+              type="primary"
+              danger
+              size="small"
+              icon={<StopOutlined />}
+              onClick={() => handleBlockWangiri(record.id)}
+            >
+              Block
+            </Button>
+            <AIDDTierBadge tier={1} compact />
+          </Space>
         ) : null,
     },
   ];

--- a/packages/web/src/pages/security/TrafficControlPage.tsx
+++ b/packages/web/src/pages/security/TrafficControlPage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Card, Table, Tag, Button, Switch, Typography, Space, Modal, Input, message } from 'antd';
 import { PlusOutlined, DeleteOutlined } from '@ant-design/icons';
 import { voxguardApi, type TrafficRule } from '../../api/voxguard';
+import { AIDDTierBadge } from '../../components/common';
 
 const { Title, Text } = Typography;
 
@@ -93,14 +94,17 @@ export const TrafficControlPage: React.FC = () => {
       title: 'Actions',
       key: 'actions',
       render: (_: unknown, record: TrafficRule) => (
-        <Button
-          type="link"
-          danger
-          icon={<DeleteOutlined />}
-          onClick={() => handleDelete(record.id)}
-        >
-          Delete
-        </Button>
+        <Space>
+          <Button
+            type="link"
+            danger
+            icon={<DeleteOutlined />}
+            onClick={() => handleDelete(record.id)}
+          >
+            Delete
+          </Button>
+          <AIDDTierBadge tier={1} compact />
+        </Space>
       ),
     },
   ];
@@ -113,9 +117,12 @@ export const TrafficControlPage: React.FC = () => {
         <Card
           title={`Traffic Rules (${rules.length})`}
           extra={
-            <Button type="primary" icon={<PlusOutlined />} onClick={() => setModalOpen(true)}>
-              Create Rule
-            </Button>
+            <Space>
+              <Button type="primary" icon={<PlusOutlined />} onClick={() => setModalOpen(true)}>
+                Create Rule
+              </Button>
+              <AIDDTierBadge tier={1} compact />
+            </Space>
           }
         >
           <Table

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -1,7 +1,7 @@
 /* ACM Admin Dashboard - Global Styles */
 
 /* Font imports */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap');
 
 /* CSS Variables for ACM Brand */
 :root {
@@ -38,6 +38,17 @@
   --acm-text-primary: #212529;
   --acm-text-secondary: #6C757D;
   --acm-border: #DEE2E6;
+
+  /* Product brand colors */
+  --color-voxguard:        #7C3AED;
+  --color-voxguard-bg:     #f5f0ff;
+  --color-voxguard-border: #c4b5fd;
+
+  --color-graphql:         #E535AB;
+  --color-graphql-bg:      #fdf2f8;
+
+  --color-im:              #06B6D4;
+  --color-im-bg:           #ecfeff;
 }
 
 /* Dark mode variables */
@@ -47,6 +58,16 @@
   --acm-text-primary: #FFFFFF;
   --acm-text-secondary: #A0A0A0;
   --acm-border: #303030;
+
+  --color-voxguard:        #a78bfa;
+  --color-voxguard-bg:     #1e1533;
+  --color-voxguard-border: #4c1d95;
+
+  --color-graphql:         #f472b6;
+  --color-graphql-bg:      #2d1326;
+
+  --color-im:              #22d3ee;
+  --color-im-bg:           #0c2a30;
 }
 
 /* Global resets and base styles */


### PR DESCRIPTION
## Summary

- **Brand color CSS tokens**: Added VoxGuard (#7C3AED), GraphQL (#E535AB), and IM (#06B6D4) brand colors with background/border variants in both light and dark mode
- **Font loading**: Added JetBrains Mono (400/500/600) alongside existing Inter via Google Fonts in both `index.html` and the CSS `@import`
- **AIDDTierBadge component**: New reusable badge component with Tier 0 (gray), Tier 1 (amber + lock), Tier 2 (red + shield) variants and compact mode
- **Notification bell dropdown**: Replaced static bell button in Header with an Ant Design Dropdown showing mock notifications (fraud alert, NCC report, system update, wangiri spike) with unread indicators and "View all" link to `/alerts`
- **AIDD T1 badges on security pages**: Added compact tier badges next to destructive action buttons on ListsManage, TrafficControl, RevenueFraud, MultiCallDetection, CompositeScoring, and RVSDashboard pages
- **NCC pages with AIDD T2 badges**: Created NCCCompliancePage (Submit to NCC, Escalate Dispute) and MNPLookupPage (Import MNP Data) with Tier 2 badges, wired into App.tsx routing

## Test plan

- [ ] `npx vite build` succeeds (verified — built in ~28s)
- [ ] Brand color CSS tokens render correctly in light and dark mode
- [ ] Inter + JetBrains Mono fonts load (check DevTools Network tab)
- [ ] Notification bell opens dropdown with 4 sample notifications, "View all" navigates to `/alerts`
- [ ] AIDD T1 badges appear next to destructive buttons on all 6 security pages
- [ ] AIDD T2 badges appear on NCC Compliance and MNP Lookup pages
- [ ] Tier badge colors: T0=gray, T1=amber, T2=red; tooltips show tier descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NCC Compliance and Mobile Number Portability (MNP) lookup pages with dedicated routes and data management functionality.
  * Enhanced notification center with a dropdown menu displaying notification details, unread counts, and quick navigation.
  * Introduced tier badge indicators across security and compliance pages for enhanced feature visibility.

* **Style**
  * Added JetBrains Mono font family alongside Inter.
  * Extended color palette with new product brand colors and their variants for improved theming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->